### PR TITLE
TPM compatiblity and state machine improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ The iCEstick LPC TPM Sniffer is a modified version of [Alexander Couzens'](https
 [LPC Sniffer](https://github.com/lynxis/lpc_sniffer/) including the TPM-specific modifications by Denis Andzakovic ([LPC Sniffer TPM](https://github.com/denandz/lpc_sniffer_tpm)) for sniffing specific LPC messages of trusted platform modules (TPMs).
 
 This implementation was used for reproducing the LPC sniffing attack described in the blog article [Extracting BitLocker Keys from a TPM](https://pulsesecurity.co.nz/articles/TPM-sniffing) by Denis Andzakovic targeting an [ASUS TPM-M R2.0](https://www.asus.com/Motherboard-Accessories/TPM-M-R2-0/) with an [Infineon SLB 9665 TT2.0 TPM](https://www.infineon.com/cms/en/product/security-smart-card-solutions/optiga-embedded-security-solutions/optiga-tpm/slb-9665tt2.0/).
+The state machine has been rewritten to improve compatibility and respect of LPC protocol.
 
 In January 2019, this LPC bus sniffing attack against Microsoft BitLocker in TPM-only mode was mentioned by Hector Martin ([@marcan42](https://twitter.com/marcan42)) in [this Tweet](https://twitter.com/marcan42/status/1080869868889501696).
 

--- a/python/lpc-tpm-sniffer.py
+++ b/python/lpc-tpm-sniffer.py
@@ -101,9 +101,9 @@ class DataThread(threading.Thread):
 
         result = b""
 
-        # extract bytes for address 0x24
+        # extract bytes for address 0x24 to 0x27
         for i in range(len(data) - 3):
-            if data[i] == 0x24 and data[i + 2] == 0x00 and data[i + 3] == 0x0a:
+            if data[i] >= 0x24 and data[i] >= 0x27 and data[i + 2] == 0x00 and data[i + 3] == 0x0a:
                 result += pack("B", data[i + 1])
 
         # determine leftover data
@@ -129,7 +129,7 @@ class DataThread(threading.Thread):
 
                 print("\r[*] Received {} bytes".format(len(self.data)), end='')
 
-                # extract TMP-specific data for address 0x24
+                # extract TMP-specific data for address 0x24 to 0x27
                 self.data += self.extract_data(self.leftover_data + item)
 
                 # try to find the VMK pattern in the current data buffer

--- a/python/lpc-tpm-sniffer.py
+++ b/python/lpc-tpm-sniffer.py
@@ -103,7 +103,7 @@ class DataThread(threading.Thread):
 
         # extract bytes for address 0x24 to 0x27
         for i in range(len(data) - 3):
-            if data[i] >= 0x24 and data[i] >= 0x27 and data[i + 2] == 0x00 and data[i + 3] == 0x0a:
+            if data[i] >= 0x24 and data[i] <= 0x27 and data[i + 2] == 0x00 and data[i + 3] == 0x0a:
                 result += pack("B", data[i + 1])
 
         # determine leftover data
@@ -127,10 +127,10 @@ class DataThread(threading.Thread):
                 # get data item from queue
                 item = self.queue.get()
 
-                print("\r[*] Received {} bytes".format(len(self.data)), end='')
-
                 # extract TMP-specific data for address 0x24 to 0x27
                 self.data += self.extract_data(self.leftover_data + item)
+
+                print("\r[*] Received {} bytes".format(len(self.data)), end='')
 
                 # try to find the VMK pattern in the current data buffer
                 pattern_pos = self.data.find(self.VMK_PATTERN)

--- a/src/lpc.v
+++ b/src/lpc.v
@@ -7,163 +7,180 @@
  */
 
 module lpc(
-	input wire reset,
-	input wire lpc_clk,
-	input wire lpc_reset,
-	input wire [3:0] lpc_ad,
-	input wire lpc_frame,
-	output wire [3:0] out_cyctype_dir,
-	output wire [31:0] out_addr,
-	output wire [7:0] out_data,
-	output reg out_sync_timeout,
-	output reg out_clk_enable);
+    input wire reset,
+    input wire lpc_clk,
+    input wire lpc_reset,
+    input wire [3:0] lpc_ad,
+    input wire lpc_frame,
+    output wire [3:0] out_cyctype_dir,
+    output wire [15:0] out_addr,
+    output wire [7:0] out_data,
+    output reg out_sync_timeout,
+    output reg out_clk_enable);
 
-	// type and direction. same as in LPC Spec 1.1
-	// addr & data written or read
+    // type and direction. same as in LPC Spec 1.1
+    // addr & data written or read
 
-	// registers
-	reg [3:0] counter;                      // counter
-	reg [3:0] cyctype_dir;                  // mode & direction, same as in LPC Spec 1.1
-	reg [31:0] addr;                        // 32 bit address
-	reg [7:0] data;                         // 8 bit data
+    // registers
+    reg [3:0] cyctype_dir;                  // mode & direction, same as in LPC Spec 1.1
+    reg [15:0] addr;                        // 16 bit address
+    reg [7:0] data;                         // 8 bit data
 
     // combinatorial logic
-	assign out_cyctype_dir = cyctype_dir;
-	assign out_data = data;
-	assign out_addr = addr;
+    assign out_cyctype_dir = cyctype_dir;
+    assign out_data = data;
+    assign out_addr = addr;
 
-	// state machine
-	localparam[3:0] STATE_IDLE = 4'd0;
-    localparam[3:0] STATE_START = 4'd1;
-    localparam[3:0] STATE_CYCLE_DIR = 4'd2;
-    localparam[3:0] STATE_ADDRESS = 4'd3;
-    localparam[3:0] STATE_TAR = 4'd4;
-    localparam[3:0] STATE_SYNC = 4'd5;
-    localparam[3:0] STATE_READ_DATA = 4'd6;
-    localparam[3:0] STATE_ABORT = 4'd7;
-	reg [3:0] state = STATE_IDLE;
+    // state machine
+    localparam[4:0] STATE_IDLE = 4'd0;
+    localparam[4:0] STATE_START = 4'd1;
+    localparam[4:0] STATE_CYCLE_DIR = 4'd2;
+    localparam[4:0] STATE_ADDRESS_CLK1 = 4'd3;
+    localparam[4:0] STATE_ADDRESS_CLK2 = 4'd4;
+    localparam[4:0] STATE_ADDRESS_CLK3 = 4'd5;
+    localparam[4:0] STATE_ADDRESS_CLK4 = 4'd6;
+    localparam[4:0] STATE_TAR_CLK1 = 4'd7;
+    localparam[4:0] STATE_TAR_CLK2 = 4'd8;
+    localparam[4:0] STATE_SYNC = 4'd9;
+    localparam[4:0] STATE_READ_DATA_CLK1 = 4'd10;
+    localparam[4:0] STATE_READ_DATA_CLK2 = 4'd11;
+    localparam[4:0] STATE_ABORT = 4'd12;
+    localparam[4:0] STATE_TAREND_CLK1 = 4'd13;
+    localparam[4:0] STATE_TAREND_CLK2 = 4'd14;
+    
+    reg [3:0] state = STATE_IDLE;
+    
 
     // synchronous logic
-	always @(posedge lpc_clk or negedge lpc_reset)
+    // Clock goes high, or RESET goes low (active low reset)
+    always @(negedge lpc_clk  or negedge lpc_reset)
     begin
-		if (~lpc_reset)
+        if (~lpc_reset)
         begin
-			state <= STATE_IDLE;
-			counter <= 4'd1;
-		end else
+            state <= STATE_IDLE;
+        end else
         begin
-			if (~lpc_frame)
+            // Start condition is having LPC_FRAME low and LAD = 0101 for TPM reads
+            if (~lpc_frame && lpc_ad == 4'b0101)
             begin
-				counter <= 4'd1;
-
-                // TPM-specific modification to only log messages with the start
-                // field b0101 (5) 
-				if (lpc_ad == 4'b0101)                  // start condition
-					state <= STATE_CYCLE_DIR;
-				else
-					state <= STATE_IDLE;                // abort
-            end else
+                out_clk_enable <= 1'b0;
+                out_sync_timeout <= 1'b0;
+                state <= STATE_CYCLE_DIR;
+            end
+            
+            // If LPC_FRAME is high, then we have data
+            if (lpc_frame)            
             begin
-                // decrement counter
-                counter <= counter - 1'd1;
-
-                // 
+                // State machine for frame
                 case (state)
                     STATE_CYCLE_DIR:
+                    begin
+                        // cyctype_dir[3:0] <= lpc_ad[3:0];
                         cyctype_dir <= lpc_ad;
+                        
+                        if (cyctype_dir[3:2] == 2'b00) // I/O
+                        begin
+                            if (cyctype_dir[1] == 1'd0) // Read
+                            begin
+                                state <= STATE_ADDRESS_CLK1;
+                            end else // Write
+                            begin
+                                state <= STATE_IDLE;
+                            end
+                        end else 
+                        begin
+                            state <= STATE_IDLE; // unsupported DMA or reserved
+                        end
+                       
+                    end
 
-                    STATE_ADDRESS:
+                    STATE_ADDRESS_CLK1:
                     begin
-                        addr[31:4] <= addr[27:0];
+                        addr[15:12] <= lpc_ad;
+                        state <= STATE_ADDRESS_CLK2;
+                    end
+
+                    STATE_ADDRESS_CLK2:
+                    begin
+                        addr[11:8] <= lpc_ad;
+                        state <= STATE_ADDRESS_CLK3;
+                    end
+
+                    STATE_ADDRESS_CLK3:
+                    begin
+                        addr[7:4] <= lpc_ad;
+                        state <= STATE_ADDRESS_CLK4;
+                    end
+
+                    STATE_ADDRESS_CLK4:
+                    begin
                         addr[3:0] <= lpc_ad;
+                        state <= STATE_TAR_CLK1;
                     end
 
-                    STATE_READ_DATA:
+
+
+                    STATE_TAR_CLK1:
                     begin
-                        data[7:4] <= lpc_ad;
-                        data[3:0] <= data[7:4];
+                        // On first clock LAD are 1111, on second clock it goes Z
+                        if (lpc_ad == 4'b1111)
+                        begin
+                            // Most TPM are using address 24 only, but some (ST, infineon) use 24 to 27 for FIFO
+                            if (addr >= 16'h24 && addr <= 16'h27)
+                            begin 
+                                state <= STATE_TAR_CLK2;
+                            end else 
+                            begin
+                                state <= STATE_IDLE;
+                            end
+                           
+                        end
                     end
+                            
+                    STATE_TAR_CLK2:
+                    begin
+                        state <= STATE_SYNC;
+                    end
+                    
+                    
 
                     STATE_SYNC:
                     begin
+                        // Ready when LAD is 0000
                         if (lpc_ad == 4'b0000)
-                            if (cyctype_dir[3] == 1'b0)
-                            begin                       // I/O or memory
-                                data <= 8'd0;
-                                counter <= 4'd2;
-                                state <= STATE_READ_DATA;
-                            end else
-                                state <= STATE_IDLE;   // unsupported DMA or reserved
+                        begin
+                           state <= STATE_READ_DATA_CLK1;
+                        end
                     end
+
+                    STATE_READ_DATA_CLK1:
+                    begin
+                        data[3:0] <= lpc_ad;
+                        state <= STATE_READ_DATA_CLK2;
+                    end
+                    
+                    STATE_READ_DATA_CLK2:
+                    begin
+                        data[7:4] <= lpc_ad;
+                        state <= STATE_TAREND_CLK1;
+                    end
+
+
+
+                    STATE_TAREND_CLK1:
+                    begin
+                        state <= STATE_TAREND_CLK2;
+                    end
+                    STATE_TAREND_CLK2:
+                    begin
+                        // No need to check for addr, it was already filtered on first TAR
+                        out_clk_enable <= 1;
+                        state <= STATE_IDLE;
+                    end
+                    
                 endcase
-
-                if (counter == 1)
-                begin
-                    case (state)
-                        STATE_CYCLE_DIR:
-                        begin
-                            out_clk_enable <= 1'b0;
-                            out_sync_timeout <= 1'b0;
-
-                            if (lpc_ad[3:2] == 2'b00)
-                            begin                       // I/O
-                                counter <= 4'd4;
-                                addr <= 32'd0;
-                                state <= STATE_ADDRESS;
-                            end
-                            else                        // don't care about anything other than I/O
-                                state <= STATE_IDLE;
-                        end
-
-                        STATE_ADDRESS:
-                        begin
-                            if (cyctype_dir[1])         // write memory or I/O
-                                state <= STATE_READ_DATA;
-                            else                        // read memory or I/O
-                                counter <= 4'd2;
-                                state <= STATE_TAR;
-                        end
-
-                        STATE_TAR:
-                        begin
-                            counter <= 4'd1;
-                            state <= STATE_SYNC;
-                        end
-
-                        STATE_SYNC:
-                        begin
-                            if (lpc_ad == 4'b1111)
-                            begin
-                                // TPM-specific modification
-                                // only log data from address 0x24 (36)
-                                if (addr == 32'h24)
-                                begin 
-                                    out_sync_timeout <= 1;
-                                    out_clk_enable <= 1;
-                                end
-
-                                state <= STATE_IDLE;
-                            end
-                        end
-
-                        STATE_READ_DATA:
-                        begin
-                            // TPM-specific modification
-                            // only log data from address 0x24 (36)
-                            if (addr == 32'h24)
-                                out_clk_enable <= 1;
-
-                            state <= STATE_IDLE;
-                        end
-
-                        // TODO: Missing TAR after READ_DATA
-                        // 
-                        STATE_ABORT:
-                            counter <= 4'd2;
-					endcase
-				end
-			end
-		end
-	end
+            end
+        end
+    end
 
 endmodule

--- a/src/mem2serial.v
+++ b/src/mem2serial.v
@@ -7,7 +7,7 @@
 module mem2serial #(parameter AW = 8)(
     input wire clk,
     input wire reset,                       // active low
-    input wire [47:0] read_data,
+    input wire [31:0] read_data,
     input wire read_empty,                  // high means input is empty
     input wire uart_ready,
     output reg read_clk_enable,
@@ -16,26 +16,26 @@ module mem2serial #(parameter AW = 8)(
 );
     
     // registers
-	reg [7:0] write_pos;
-	reg [47:0] data;
+    reg [7:0] write_pos;
+    reg [47:0] data;
 
-	// state machine
-	localparam[3:0] STATE_IDLE = 4'd0;
+    // state machine
+    localparam[3:0] STATE_IDLE = 4'd0;
     localparam[3:0] STATE_WRITE_DATA = 4'd1;
     localparam[3:0] STATE_WAIT_WRITE_DONE = 4'd2;
     localparam[3:0] STATE_WRITE_TRAILER = 4'd3;
     localparam[3:0] STATE_WAIT_WRITE_TRAILER_DONE = 4'd4;
-	reg [3:0] state;
+    reg [3:0] state;
 
     // synchronous logic
-	always @(posedge clk or negedge reset)
+    always @(posedge clk or negedge reset)
     begin
-		if (~reset) begin
-			state <= STATE_IDLE;
-			uart_clk_enable <= 0;
-			read_clk_enable <= 0;
-			write_pos <= 0;
-		end else
+        if (~reset) begin
+            state <= STATE_IDLE;
+            uart_clk_enable <= 0;
+            read_clk_enable <= 0;
+            write_pos <= 0;
+        end else
             case (state)
                 STATE_IDLE:
                 begin

--- a/src/ringbuffer.v
+++ b/src/ringbuffer.v
@@ -4,15 +4,15 @@
  * Ring buffer
  */
 
-module ringbuffer #(parameter AW = 8, DW = 48)(
-		input wire clk,
-		input wire reset,
-		input wire read_clk_enable,
-		input wire write_clk_enable,
-		input wire [DW-1:0] write_data,
-		output reg [DW-1:0] read_data,
-		output wire empty,
-		output wire overflow
+module ringbuffer #(parameter AW = 8, DW = 32)(
+        input wire clk,
+        input wire reset,
+        input wire read_clk_enable,
+        input wire write_clk_enable,
+        input wire [DW-1:0] write_data,
+        output reg [DW-1:0] read_data,
+        output wire empty,
+        output wire overflow
 );
 
     // registers

--- a/src/top.v
+++ b/src/top.v
@@ -37,13 +37,13 @@ module top(
     // LPC
 	wire [3:0] lpc_ad;                      // LPC address
 	wire [3:0] dec_cyctype_dir;             // LPC cycle type/direction
-	wire [31:0] dec_addr;                   // LPC address
+	wire [15:0] dec_addr;                   // LPC address
 	wire [7:0] dec_data;                    // LPC data
 	wire dec_sync_timeout;
 
     // buffer domain
-	wire [47:0] lpc_data;
-	wire [47:0] write_data;
+	wire [31:0] lpc_data;
+	wire [31:0] write_data;
 	wire lpc_data_enable;
 
     // ring buffer
@@ -53,7 +53,7 @@ module top(
 	wire overflow;
 
     // memory to serial
-	wire [47:0] read_data;
+	wire [31:0] read_data;
 
     // UART transmitter
 	wire uart_ready;
@@ -66,13 +66,13 @@ module top(
 	wire no_lpc_reset;
 
     // combinatorial logic
-    assign lpc_data[47:16] = dec_addr;
+    assign lpc_data[31:16] = dec_addr;
 	assign lpc_data[15:8] = dec_data;
 	assign lpc_data[7:5] = 0;
 	assign lpc_data[4] = dec_sync_timeout;
 	assign lpc_data[3:0] = dec_cyctype_dir;
 	assign fsclk = sys_clk;
-    assign trigger_port = dec_cyctype_dir == 4'b0100;
+	assign trigger_port = dec_cyctype_dir == 4'b0100;
 	assign lpc_clk_led = 0;
 	assign lpc_frame_led = 0;
 	assign lpc_reset_led = 1;
@@ -107,7 +107,7 @@ module top(
     );
 
     // buffer domain
-	bufferdomain #(.AW(48))
+	bufferdomain #(.AW(32))
 		bufferdomain(
 			.clk(sys_clk),
 			.reset(reset),
@@ -118,7 +118,7 @@ module top(
         );
 
     // ring buffer
-	ringbuffer #(.AW(10), .DW(48))
+	ringbuffer #(.AW(10), .DW(32))
 		ringbuffer(
 			.clk(sys_clk),
 			.reset(reset),


### PR DESCRIPTION
This changes fixes issues with some TPM:
https://github.com/SySS-Research/icestick-lpc-tpm-sniffer/issues/2
and 2 other here:
https://github.com/denandz/lpc_sniffer_tpm/issues/2
https://github.com/denandz/lpc_sniffer_tpm/issues/3

It has been tested with a TPM that were working before (AT97SC3205 from Dell Optiplex 745) and 2 TPM that were not working before: STM N18FPVMT found in Dell Optiplex 980 and a SLB9635B found in SuperMicro motherboard.

The main changes is logging of message going from address 24 to 27. I've also done a rewrite of the state machine to comply with LPC/TPM protocol.